### PR TITLE
downgrading to ipython 8.23

### DIFF
--- a/report/environment.yml
+++ b/report/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - sympy
   - fenics
   - numpy=1.24
-  - ipython=8.24
+  - ipython=8.23
   - pip
   - pip:
     - festim

--- a/report/environment.yml
+++ b/report/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - sympy
   - fenics
   - numpy=1.24
+  - ipython=8.24
   - pip
   - pip:
     - festim


### PR DESCRIPTION
I noticed a warning in the documentation whenever we are using matplotlib.
After a bit of investigation it appears we need either to downgrade ipython to <8.24 or upgrade matplotlib to 3.9.0
Unfortunately [matplotlib 3.9 is not available on conda yet](https://github.com/conda-forge/matplotlib-feedstock/pull/382)

So in the meantime, we will pin the version of ipython