### PR TITLE
Implementation of tagging using sphinx-tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build Files
 report/_build
+report/_tags
 
 # Jupyter Notebooks
 *.ipynb

--- a/report/_config.yml
+++ b/report/_config.yml
@@ -52,3 +52,15 @@ sphinx:
     tags_extension : ["md"]
     tags_page_title : "All Tags"
     suppress_warnings: ["etoc.toctree"]
+    tags_badge_colors: {
+      "MMS": "success",
+      "MES": "success",
+      "*D": "secondary",
+    }
+    tags_index_head: "Cases categorised by tag"
+    tags_intro_text: "🏷 Tags:"
+    tags_overview_title: "🏷 Tags"
+    tags_page_header: "Cases with this tag"
+    tags_page_title: "🏷 Tag"
+
+

--- a/report/_config.yml
+++ b/report/_config.yml
@@ -48,6 +48,7 @@ sphinx:
     - sphinx_tags
   config:
     tags_create_tags : True
-    tags_extension : "md"
+    tags_create_badges: True
+    tags_extension : ["md"]
     tags_page_title : "All Tags"
     suppress_warnings: ["etoc.toctree"]

--- a/report/_config.yml
+++ b/report/_config.yml
@@ -41,3 +41,10 @@ parse:
     # including those that are enabled by default!
     - amsmath
     - dollarmath
+
+# add sphinx configuration
+sphinx:
+  extra_extensions:
+    - sphinx_tags
+  config:
+    tags_create_tags : True

--- a/report/_config.yml
+++ b/report/_config.yml
@@ -48,3 +48,6 @@ sphinx:
     - sphinx_tags
   config:
     tags_create_tags : True
+    tags_extension : "md"
+    tags_page_title : "All Tags"
+    suppress_warnings: ["etoc.toctree"]

--- a/report/_toc.yml
+++ b/report/_toc.yml
@@ -8,6 +8,7 @@ parts:
     chapters:
     - file: intro
     - file: vv
+    - file: _tags/tagsindex.md
   - caption: Verification
     chapters:
       - file: verification/methods

--- a/report/_toc.yml
+++ b/report/_toc.yml
@@ -8,7 +8,6 @@ parts:
     chapters:
     - file: intro
     - file: vv
-    - file: _tags/tagsindex.md
   - caption: Verification
     chapters:
       - file: verification/methods
@@ -26,6 +25,7 @@ parts:
     chapters:
       - file: validation/plasma-driven-permeation/plasma-driven-permeation
       - file: validation/thermodesorption_spectra/ogorodnikova/ogorodnikova-tds
-  - caption: Bibliography
+  - caption: Appendices
     chapters:
     - file: bibliography
+    - file: _tags/tagsindex.md

--- a/report/environment.yml
+++ b/report/environment.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   - python
   - jupyter-book
+  - sphinx-tags
   - numpy
   - matplotlib
   - sphinx

--- a/report/validation/plasma-driven-permeation/plasma-driven-permeation.md
+++ b/report/validation/plasma-driven-permeation/plasma-driven-permeation.md
@@ -12,10 +12,11 @@ kernelspec:
   name: python3
 ---
 
-```{tags} 1D
-```
 
 # Plasma-driven permeation
+
+```{tags} 1D
+```
 
 This validation case is a plasma-driven permeation performed at INL in 1985 {cite}`anderl_tritium_1986`.
 Deuterium ions at 3 keV was implanted in a 0.5 mm thick sample of 316 stainless steel variant called primary candidate alloy (PCA).

--- a/report/validation/plasma-driven-permeation/plasma-driven-permeation.md
+++ b/report/validation/plasma-driven-permeation/plasma-driven-permeation.md
@@ -12,6 +12,9 @@ kernelspec:
   name: python3
 ---
 
+```{tags} 1D
+```
+
 # Plasma-driven permeation
 
 This validation case is a plasma-driven permeation performed at INL in 1985 {cite}`anderl_tritium_1986`.

--- a/report/validation/thermodesorption_spectra/ogorodnikova/ogorodnikova-tds.md
+++ b/report/validation/thermodesorption_spectra/ogorodnikova/ogorodnikova-tds.md
@@ -12,10 +12,10 @@ kernelspec:
   name: python3
 ---
 
+# Thermo-desorption spectrum
+
 ```{tags} 1D, TDS
 ```
-
-# Thermo-desorption spectrum
 
 This validation case is a thermo-desorption spectrum measurement perfomed by Ogorodnikova et al. {cite}`ogorodnikova_deuterium_2003`.
 

--- a/report/validation/thermodesorption_spectra/ogorodnikova/ogorodnikova-tds.md
+++ b/report/validation/thermodesorption_spectra/ogorodnikova/ogorodnikova-tds.md
@@ -12,6 +12,9 @@ kernelspec:
   name: python3
 ---
 
+```{tags} 1D, TDS
+```
+
 # Thermo-desorption spectrum
 
 This validation case is a thermo-desorption spectrum measurement perfomed by Ogorodnikova et al. {cite}`ogorodnikova_deuterium_2003`.

--- a/report/verification/depleting_source.md
+++ b/report/verification/depleting_source.md
@@ -12,6 +12,9 @@ kernelspec:
   name: python3
 ---
 
+```{tags} 2D, MES
+```
+
 # Diffusion from a Depleting Source
 
 This verification case {cite}`ambrosek_verification_2008` consists of an enclosure containing an initial quantity of hydrogen gas (at an initial pressure $P_0$).

--- a/report/verification/depleting_source.md
+++ b/report/verification/depleting_source.md
@@ -12,10 +12,11 @@ kernelspec:
   name: python3
 ---
 
-```{tags} 2D, MES
-```
 
 # Diffusion from a Depleting Source
+
+```{tags} 2D, MES
+```
 
 This verification case {cite}`ambrosek_verification_2008` consists of an enclosure containing an initial quantity of hydrogen gas (at an initial pressure $P_0$).
 The hydrogen can dissociate on the inner surface of the enclosure and then permeate through the walls.

--- a/report/verification/mes_radioactive_decay.md
+++ b/report/verification/mes_radioactive_decay.md
@@ -12,10 +12,10 @@ kernelspec:
   name: python3
 ---
 
+# Radioactive decay 1D
+
 ```{tags} 1D, MES, RadioactiveDecay
 ```
-
-# Radioactive decay 1D
 
 This example is a radioactive decay (`RadioactiveDecay`) problem on simple unit interval with a uniform mobile concentration and no boundary condition.
 

--- a/report/verification/mes_radioactive_decay.md
+++ b/report/verification/mes_radioactive_decay.md
@@ -12,6 +12,9 @@ kernelspec:
   name: python3
 ---
 
+```{tags} 1D, MES, RadioactiveDecay
+```
+
 # Radioactive decay 1D
 
 This example is a radioactive decay (`RadioactiveDecay`) problem on simple unit interval with a uniform mobile concentration and no boundary condition.

--- a/report/verification/mms/discontinuity.md
+++ b/report/verification/mms/discontinuity.md
@@ -8,6 +8,9 @@ jupytext:
     jupytext_version: 1.16.2
 ---
 
+```{tags} 2D, MMS
+```
+
 # Diffusion multi-material
 
 The first MMS problem has two materials (denoted, respectively, by left and right).

--- a/report/verification/mms/discontinuity.md
+++ b/report/verification/mms/discontinuity.md
@@ -8,10 +8,10 @@ jupytext:
     jupytext_version: 1.16.2
 ---
 
+# Diffusion multi-material
+
 ```{tags} 2D, MMS
 ```
-
-# Diffusion multi-material
 
 The first MMS problem has two materials (denoted, respectively, by left and right).
 In material left, the solubility is $K_{S,\mathrm{left}} = 3$ and the diffusivity is $D_\mathrm{left} = 2$.

--- a/report/verification/mms/fluxes.md
+++ b/report/verification/mms/fluxes.md
@@ -12,10 +12,11 @@ kernelspec:
   name: python3
 ---
 
-```{tags} 2D, MMS, DissociationFlux
-```
 
 # Diffusion with dissociation flux
+
+```{tags} 2D, MMS, DissociationFlux
+```
 
 This example is a diffusion problem with one boundary under a dissociation flux (`DissociationFlux`).
 

--- a/report/verification/mms/fluxes.md
+++ b/report/verification/mms/fluxes.md
@@ -12,6 +12,9 @@ kernelspec:
   name: python3
 ---
 
+```{tags} 2D, MMS, DissociationFlux
+```
+
 # Diffusion with dissociation flux
 
 This example is a diffusion problem with one boundary under a dissociation flux (`DissociationFlux`).

--- a/report/verification/mms/heat_transfer.md
+++ b/report/verification/mms/heat_transfer.md
@@ -8,10 +8,11 @@ jupytext:
     jupytext_version: 1.16.2
 ---
 
-```{tags} 2D, MMS, HeatTransferProblem
-```
 
 # Heat transfer multi-material
+
+```{tags} 2D, MMS, HeatTransferProblem
+```
 
 This case verifies the implementation of the heat transfer solver in FESTIM.
 Two materials with different thermal conductivities are defined: $\lambda_\mathrm{left} = 2$ and $\lambda_\mathrm{right} = 5$.

--- a/report/verification/mms/heat_transfer.md
+++ b/report/verification/mms/heat_transfer.md
@@ -8,6 +8,9 @@ jupytext:
     jupytext_version: 1.16.2
 ---
 
+```{tags} 2D, MMS, HeatTransferProblem
+```
+
 # Heat transfer multi-material
 
 This case verifies the implementation of the heat transfer solver in FESTIM.

--- a/report/verification/mms/heat_transfer.md
+++ b/report/verification/mms/heat_transfer.md
@@ -11,7 +11,7 @@ jupytext:
 
 # Heat transfer multi-material
 
-```{tags} 2D, MMS, HeatTransferProblem
+```{tags} 2D, MMS, HeatTransferProblem, Multi-material
 ```
 
 This case verifies the implementation of the heat transfer solver in FESTIM.

--- a/report/verification/mms/radioactive_decay.md
+++ b/report/verification/mms/radioactive_decay.md
@@ -12,6 +12,9 @@ kernelspec:
   name: python3
 ---
 
+```{tags} 2D, MMS, RadioactiveDecay
+```
+
 # Radioactive decay 2D
 
 This MMS case verifies the implementation of radioactive decay in FESTIM.

--- a/report/verification/mms/radioactive_decay.md
+++ b/report/verification/mms/radioactive_decay.md
@@ -12,10 +12,10 @@ kernelspec:
   name: python3
 ---
 
+# Radioactive decay 2D
+
 ```{tags} 2D, MMS, RadioactiveDecay
 ```
-
-# Radioactive decay 2D
 
 This MMS case verifies the implementation of radioactive decay in FESTIM.
 We will only consider diffusion of hydrogen in a unit square domain $\Omega$ at steady state with a homogeneous diffusion coefficient $D$.

--- a/report/verification/mms/simple.md
+++ b/report/verification/mms/simple.md
@@ -12,10 +12,11 @@ kernelspec:
   name: python3
 ---
 
-```{tags} 2D, MMS
-```
 
 # Simple diffusion case
+
+```{tags} 2D, MMS
+```
 
 This is a simple MMS example.
 We will only consider diffusion of hydrogen in a unit square domain $\Omega$ at steady state with an homogeneous diffusion coefficient $D$.

--- a/report/verification/mms/simple.md
+++ b/report/verification/mms/simple.md
@@ -12,6 +12,9 @@ kernelspec:
   name: python3
 ---
 
+```{tags} 2D, MMS
+```
+
 # Simple diffusion case
 
 This is a simple MMS example.

--- a/report/verification/mms/trapping.md
+++ b/report/verification/mms/trapping.md
@@ -8,6 +8,9 @@ jupytext:
     jupytext_version: 1.16.2
 ---
 
+```{tags} 2D, MMS, Trapping
+```
+
 # Single trap
 
 The MMS case verifies the implementation of trapping in FESTIM.

--- a/report/verification/mms/trapping.md
+++ b/report/verification/mms/trapping.md
@@ -8,10 +8,10 @@ jupytext:
     jupytext_version: 1.16.2
 ---
 
+# Single trap
+
 ```{tags} 2D, MMS, Trapping
 ```
-
-# Single trap
 
 The MMS case verifies the implementation of trapping in FESTIM.
 Only one trap is considered for simplicity, but the same principle applies for more traps.

--- a/report/verification/mms/trapping.md
+++ b/report/verification/mms/trapping.md
@@ -10,7 +10,7 @@ jupytext:
 
 # Single trap
 
-```{tags} 2D, MMS, Trapping
+```{tags} 2D, MMS, Trapping, Multi-material
 ```
 
 The MMS case verifies the implementation of trapping in FESTIM.


### PR DESCRIPTION
Added [sphinx-tags](https://sphinx-tags.readthedocs.io/en/latest/) to the build requirements.

Had to supress warnings from Jupyter Book's [external-toc](https://sphinx-external-toc.readthedocs.io/en/latest/intro.html) extension from using external `toctree`s  due to sphinx-tags generating some for the tag pages.
The supression looks like
```yml
sphinx:
  config:
    suppress_warnings: ["etoc.toctree"]
```
from [this issue](https://github.com/melissawm/sphinx-tags/issues/48) and is present in the book's config.

Resolves #23 .