### PR TITLE
Fix MMS bug

### DIFF
--- a/report/verification/mms/simple.md
+++ b/report/verification/mms/simple.md
@@ -243,7 +243,7 @@ for n in ns:
             return on_boundary
 
     boundary = Boundary()
-    boundary.mark(surface_markers, 2)
+    boundary.mark(surface_markers, 1)
 
     my_model.mesh = F.Mesh(
         fenics_mesh, volume_markers=volume_markers, surface_markers=surface_markers

--- a/report/verification/mms/simple.md
+++ b/report/verification/mms/simple.md
@@ -77,7 +77,7 @@ class Boundary(f.SubDomain):
         return on_boundary
 
 boundary = Boundary()
-boundary.mark(surface_markers, 2)
+boundary.mark(surface_markers, 1)
 
 # Create the FESTIM model
 my_model = F.Simulation()
@@ -98,7 +98,7 @@ my_model.sources = [
 ]
 
 my_model.boundary_conditions = [
-    F.DirichletBC(surfaces=[2], value=exact_solution, field="solute"),
+    F.DirichletBC(surfaces=[1], value=exact_solution, field="solute"),
 ]
 
 my_model.materials = F.Material(id=1, D_0=D, E_D=0)

--- a/report/verification/mms/simple.md
+++ b/report/verification/mms/simple.md
@@ -12,7 +12,6 @@ kernelspec:
   name: python3
 ---
 
-
 # Simple diffusion case
 
 ```{tags} 2D, MMS
@@ -52,7 +51,7 @@ We can then run a FESTIM model with these values and compare the numerical solut
 
 ## FESTIM code
 
-```{code-cell} ipython3
+```{code-cell}
 import festim as F
 import sympy as sp
 import fenics as f
@@ -111,7 +110,7 @@ my_model.run()
 
 ## Comparison with exact solution
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 c_exact = f.Expression(sp.printing.ccode(exact_solution), degree=4)
@@ -213,7 +212,7 @@ It is also possible to compute how the numerical error decreases as we increase 
 By iteratively refining the mesh, we find that the error exhibits a second order convergence rate.
 This is expected for this particular problem as first order finite elements are used.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 errors = []


### PR DESCRIPTION
Thanks @rekomodo for spotting this out!

The bug was that regardless of the source term we put in, the computed and exact solution always agreed.

That's because we were tagging all facets (including internal ones) with the same tag and therefore the dirichlet BC was enforced everywhere!


https://github.com/festim-dev/FESTIM/issues/708 would've helped in this case