### PR TITLE
added gxx to env to fix compiling issues

### DIFF
--- a/report/environment.yml
+++ b/report/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - fenics
   - numpy=1.24
   - ipython=8.23
+  - gxx  # TODO after this is fixed https://github.com/conda-forge/fenics-feedstock/issues/204
   - pip
   - pip:
     - festim


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/fenics-feedstock/issues/204 adding gxx to the env fixes the compiling issues