### PR TITLE
fixed missing Live Code button on changed files

### DIFF
--- a/report/verification/mms/discontinuity.md
+++ b/report/verification/mms/discontinuity.md
@@ -6,6 +6,10 @@ jupytext:
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.16.2
+kernelspec:
+  display_name: vv-festim-report-env
+  language: python
+  name: python3
 ---
 
 # Diffusion multi-material

--- a/report/verification/mms/heat_transfer.md
+++ b/report/verification/mms/heat_transfer.md
@@ -6,6 +6,10 @@ jupytext:
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.16.2
+kernelspec:
+  display_name: vv-festim-report-env
+  language: python
+  name: python3
 ---
 
 

--- a/report/verification/mms/trapping.md
+++ b/report/verification/mms/trapping.md
@@ -6,6 +6,10 @@ jupytext:
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.16.2
+kernelspec:
+  display_name: vv-festim-report-env
+  language: python
+  name: python3
 ---
 
 # Single trap


### PR DESCRIPTION
I saw that the pages without the button were missing the kernelspec config up-top, so I added it in, and it's fixed.
This config to be precise
```
kernelspec:
  display_name: vv-festim-report-env
  language: python
  name: python3
```

Thanks for spotting this!
PS: You can ignore the two closed PRs, I got used to it auto-merging into main so I didn't know how to choose what to merge into 😅.