### PR TITLE
Pin FESTIM version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - scipy
   - pip
   - pip:
-    - festim
+    - festim==1.3


### PR DESCRIPTION
I noticed we were using the `latest` festim version but we should have a pinned version to avoid breaking things.