### PR TITLE
Add mpich to env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - sphinx
   - sympy
   - fenics
+  - mpich
   - numpy=1.24
   - ipython=8.23
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - sphinx
   - sympy
   - fenics
+  - mpi4py<4
   - mpich
   - numpy=1.24
   - ipython=8.23


### PR DESCRIPTION
This is an attempt at fixing the warning we see in the compiled docs.

```
[build-25164186-project-1052576-festim-vv-report:04102] mca_base_component_repository_open: unable to open mca_btl_openib: librdmacm.so.1: cannot open shared object file: No such file or directory (ignored)

```

Following the recommendations of https://github.com/conda-forge/fenics-feedstock/issues/211#issuecomment-2262607513