### PR TITLE
Refactored TMAP 1da-1db cases for FESTIM2 

### DIFF
--- a/report/_toc.yml
+++ b/report/_toc.yml
@@ -31,7 +31,7 @@ parts:
           - file: verification/mes/tmap_1b
           - file: verification/mes/tmap_1c
           - file: verification/mes/tmap_1da
-      #     - file: verification/mes/tmap_1db
+          - file: verification/mes/tmap_1db
   - caption: Validation
     chapters:
   #     - file: validation/plasma-driven-permeation/plasma-driven-permeation

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -46,13 +46,13 @@ $$
 
 where $c_{\mathrm{m},0}$ is the steady concentration of mobile atoms at $x=0$. This analytical solution was obtained from TMAP7's V&V report {cite}`ambrosek_verification_2008`, case Val-1da.
 
-For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13}$, $D=1 \ \mathrm{m}^2/\mathrm{s}$, and $E_p/k_\mathrm{B}=100 \ \mathrm{K}$ are used to obtain $\zeta \approx 91.48 c_\mathrm{m} / \rho$.
+For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13}$, $D=1 \ \mathrm{m}^2 \mathrm{s}^{-1}$, and $E_p/k_\mathrm{B}=100 \ \mathrm{K}$ are used to obtain $\zeta \approx 91.48 c_\mathrm{m} / \rho$.
 
 +++
 
 ## FESTIM Code
 
-```{code-cell} ipython3
+```{code-cell}
 import festim as F
 import numpy as np
 
@@ -60,7 +60,7 @@ import numpy as np
 n = 3.162e22
 rho = 1e-1 * n
 D_0 = 1
-E_D = 0.
+E_D = 0.0
 k_0 = 1e15 / n
 p_0 = 1e13
 E_p = 100 * F.k_B
@@ -119,14 +119,14 @@ my_model.run()
 
 ## Comparison with exact solution
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 import plotly.graph_objects as go
 import plotly.express as px
 
 a = np.sqrt(1e-15)
-zeta = (a**2 * 1e13  * n / D_0 * np.exp((E_D-E_p)/F.k_B/T) + c_m) / rho  #(6 * rho_W * np.exp((E_D - E_p) / (F.k_B * T)) + c_m * N_A) / (rho_W * 1e-3)
+zeta = (a**2 * 1e13 * n / D_0 * np.exp((E_D - E_p) / F.k_B / T) + c_m) / rho
 D_eff = D_0 / (1 + 1 / zeta)
 
 # plot computed solution
@@ -137,7 +137,7 @@ fig = go.Figure()
 
 festim_plot = go.Scatter(
     x=t,
-    y=computed_solution / 1e18,
+    y=computed_solution,
     mode="lines",
     line=dict(width=3, color=px.colors.qualitative.Plotly[1]),
     name="FESTIM",
@@ -152,25 +152,21 @@ exp_part = np.exp(-(m**2) * t[:, None] / 2 / tau)
 
 # Calculate the 'add' part for all m values and sum them up for each t
 add = 2 * (-1) ** m * exp_part
-series = 1 + add.sum(
-    axis=1
-)  # Sum along the m dimension and add 1 for the initial ones
+series = 1 + add.sum(axis=1)  # Sum along the m dimension and add 1 for the initial ones
 
 exact_solution = c_m * D_0 / sample_depth * series
 
 exact_plot = go.Scatter(
     x=t,
-    y=exact_solution / 1e18,
+    y=exact_solution,
     mode="markers",
     marker=dict(size=9, opacity=0.5, color=px.colors.qualitative.Plotly[0]),
     name="exact",
 )
 
 fig.add_traces([exact_plot, festim_plot])
-fig.update_xaxes(title_text="Time, s", range=[0,10])
-fig.update_yaxes(
-    title_text="Downstream flux, 10<sup>18</sup> H m<sup>-2</sup>s<sup>-1</sup>"
-)
+fig.update_xaxes(title_text="Time, s", range=[0, 10])
+fig.update_yaxes(title_text="Downstream flux, H m<sup>-2</sup>s<sup>-1</sup>")
 fig.update_layout(template="simple_white", height=600)
 
 # The writing-reading block below is needed to avoid the issue with compatibility

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -32,7 +32,7 @@ $\nu \ (\mathrm{s}^{-1})$, the Debye frequency \
 $\rho$ is the trapping site fraction, \
 $c_\mathrm{m}$ is the mobile atom fraction.
 
-In the effective diffusivity regime, $\zeta \gg c_\mathrm{m} / \rho$ and the hydrogen transport can be described with an effective diffusivity $\mathrm{D_\text{eff}}$:
+In the effective diffusivity regime, $\zeta \gg c_\mathrm{m} / \rho$ and the hydrogen transport can be described with an effective diffusivity $D_\mathrm{eff}$:
 
 $$
     D_\text{eff} = \frac{D}{1 + \frac{1}{\zeta}}
@@ -46,7 +46,7 @@ $$
 
 where $c_{\mathrm{m},0}$ is the steady concentration of mobile atoms at $x=0$. This analytical solution was obtained from TMAP7's V&V report {cite}`ambrosek_verification_2008`, case Val-1da.
 
-For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13}$, $D=1 \ \mathrm{m}^2 \mathrm{s}^{-1}$, and $E_p/k_\mathrm{B}=100 \ \mathrm{K}$ are used to obtain $\zeta \approx 91.48 c_\mathrm{m} / \rho$.
+For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13} \ \mathrm{s}^{-1}$, $D=1 \ \mathrm{m}^2 \mathrm{s}^{-1}$, and $E_p/k_\mathrm{B}=100 \ \mathrm{K}$ are used to obtain $\zeta \approx 91.48 c_\mathrm{m} / \rho$.
 
 +++
 

--- a/report/verification/mes/tmap_1db.md
+++ b/report/verification/mes/tmap_1db.md
@@ -17,7 +17,7 @@ kernelspec:
 ```{tags} 1D, MES, transient, trapping
 ```
 
-This verification case consists of a slab of depth $l = 1 \ \mathrm{m}$ with one trap under the effective diffusivity regime.
+This verification case consists of a slab of depth $l = 1 \ \mathrm{m}$ with one trap under the strong trapping regime.
 
 A trapping parameter $\zeta$ is defined by
 
@@ -42,7 +42,7 @@ $$
 
 where $c_{\mathrm{m},0}$ is the steady concentration of mobile atoms at $x=0$. This analytical solution was obtained from TMAP7's V&V report {cite}`ambrosek_verification_2008`, case Val-1db.
 
-For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13}$, $D=1 \ \mathrm{m}^2 \mathrm{s}^{-1}$, and $E_p/k_\mathrm{B}=10000 \ \mathrm{K}$ are used to obtain $\zeta \approx 1.00454 c_\mathrm{m} / \rho$.
+For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13} \ \mathrm{s}^{-1}$, $D=1 \ \mathrm{m}^2 \mathrm{s}^{-1}$, and $E_p/k_\mathrm{B}=10000 \ \mathrm{K}$ are used to obtain $\zeta \approx 1.00454 c_\mathrm{m} / \rho$.
 
 +++
 

--- a/report/verification/mes/tmap_1db.md
+++ b/report/verification/mes/tmap_1db.md
@@ -42,7 +42,7 @@ $$
 
 where $c_{\mathrm{m},0}$ is the steady concentration of mobile atoms at $x=0$. This analytical solution was obtained from TMAP7's V&V report {cite}`ambrosek_verification_2008`, case Val-1db.
 
-For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13}$, $D=1 \ \mathrm{m}^2/\mathrm{s}$, and $E_p/k_\mathrm{B}=10000 \ \mathrm{K}$ are used to obtain $\zeta \approx 1.00454 c_\mathrm{m} / \rho$.
+For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13}$, $D=1 \ \mathrm{m}^2 \mathrm{s}^{-1}$, and $E_p/k_\mathrm{B}=10000 \ \mathrm{K}$ are used to obtain $\zeta \approx 1.00454 c_\mathrm{m} / \rho$.
 
 +++
 
@@ -56,7 +56,7 @@ import numpy as np
 n = 3.162e22
 rho = 1e-1 * n
 D_0 = 1
-E_D = 0.
+E_D = 0.0
 k_0 = 1e15 / n
 p_0 = 1e13
 E_p = 10000 * F.k_B
@@ -136,28 +136,28 @@ time_exact = sample_depth**2 * rho / (2 * c_m * D_0)
 fig = go.Figure()
 
 fig.add_traces(
-        go.Scatter(
-            x=t,
-            y=computed_solution / 1e18,
-            mode="lines",
-            line=dict(width=3, color=px.colors.qualitative.Plotly[1]),
-            name="FESTIM",
-        )
+    go.Scatter(
+        x=t,
+        y=computed_solution,
+        mode="lines",
+        line=dict(width=3, color=px.colors.qualitative.Plotly[1]),
+        name="FESTIM",
+    )
 )
 
 fig.add_traces(
-        go.Scatter(
-            x=[time_exact,time_exact],
-            y=[0,4],
-            mode="lines",
-            line=dict(width=3, color=px.colors.qualitative.Plotly[0], dash="dash"),
-            name="Analytical breakthrough time",
-        )
+    go.Scatter(
+        x=[time_exact, time_exact],
+        y=[0, 4e18],
+        mode="lines",
+        line=dict(width=3, color=px.colors.qualitative.Plotly[0], dash="dash"),
+        name="Analytical breakthrough time",
+    )
 )
 
-fig.update_xaxes(title_text="Time, s", range=[0,1000])
+fig.update_xaxes(title_text="Time, s", range=[0, 1000])
 fig.update_yaxes(
-    title_text="Downstream flux, 10<sup>18</sup> H m<sup>-2</sup>s<sup>-1</sup>", range=[0,3.25]
+    title_text="Downstream flux, H m<sup>-2</sup>s<sup>-1</sup>", range=[0, 3.25e18]
 )
 fig.update_layout(template="simple_white", height=600)
 


### PR DESCRIPTION
This PR refactors TMAP 1da case and introduces TMAP 1db. The input parameters were taken from [TMAP8 V&V](https://mooseframework.inl.gov/TMAP8/verification_and_validation/ver-1d.html), which are close to those used in TMAP7 V&V. In addition, the description of cases was updated to add details.