### PR TITLE
Update V-V book to include the simple transient case and fix the broken cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ jupyter-book build report --all
 Run [`jupytext --sync`](https://jupytext.readthedocs.io/en/latest/using-cli.html) on a case's markdown file to generate a matching [Jupyter notebook](https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/what_is_jupyter.html). Run [`jupytext --sync`](https://jupytext.readthedocs.io/en/latest/using-cli.html) again to sync the changes to the markdown file.
 
 See [this page](./report/how_to.md/#how-to-contribute) for more instructions.
+
+To convert a notebook to myst run:
+```
+jupytext --set-formats ipynb,myst notebook_path.ipynb 
+```

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   - python = 3.11.14
-  - jupyter-book
+  - jupyter-book<2.0
   - jupytext # necessary to open MyST files using BinderHub https://jupyterbook.org/en/stable/interactive/launchbuttons.html#launchbuttons-binder
   - sphinx-tags
   - pyvista

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python
+  - python=3.11
   - jupyter-book<2.0
   - jupytext # necessary to open MyST files using BinderHub https://jupyterbook.org/en/stable/interactive/launchbuttons.html#launchbuttons-binder
   - sphinx-tags

--- a/environment.yml
+++ b/environment.yml
@@ -19,8 +19,11 @@ dependencies:
   - ipython=8.23
   - scipy
   - plotly
-  - festim=2.0a3
+  - festim=2.0b0
   - plotly
+  - sphinxcontrib-bibtex>=2.6
+  - pybtex>=0.25
+  - pybtex-docutils>=1.0.3
   - pip
   - pip:
     - h_transport_materials

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python = 3.11
+  - python
   - jupyter-book<2.0
   - jupytext # necessary to open MyST files using BinderHub https://jupyterbook.org/en/stable/interactive/launchbuttons.html#launchbuttons-binder
   - sphinx-tags

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python 
+  - python = 3.11
   - jupyter-book<2.0
   - jupytext # necessary to open MyST files using BinderHub https://jupyterbook.org/en/stable/interactive/launchbuttons.html#launchbuttons-binder
   - sphinx-tags
@@ -21,7 +21,6 @@ dependencies:
   - plotly
   - festim=2.0b0
   - sphinxcontrib-bibtex>=2.6
-  - pybtex>=0.25
   - pybtex-docutils>=1.0.3
   - ipywidgets
   - widgetsnbextension
@@ -30,4 +29,5 @@ dependencies:
   - pip
   - pip:
     - h_transport_materials
+    - pybtex>=0.25
     - pyvista[all,trame]  # trame cannot be installed on conda

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python
+  - python = 3.11.14
   - jupyter-book
   - jupytext # necessary to open MyST files using BinderHub https://jupyterbook.org/en/stable/interactive/launchbuttons.html#launchbuttons-binder
   - sphinx-tags
@@ -20,10 +20,13 @@ dependencies:
   - scipy
   - plotly
   - festim=2.0b0
-  - plotly
   - sphinxcontrib-bibtex>=2.6
   - pybtex>=0.25
   - pybtex-docutils>=1.0.3
+  - ipywidgets
+  - widgetsnbextension
+  - jupyterlab_widgets
+  - tqdm
   - pip
   - pip:
     - h_transport_materials

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python = 3.11.14
+  - python 
   - jupyter-book<2.0
   - jupytext # necessary to open MyST files using BinderHub https://jupyterbook.org/en/stable/interactive/launchbuttons.html#launchbuttons-binder
   - sphinx-tags

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - ipywidgets
   - widgetsnbextension
   - jupyterlab_widgets
-  - tqdm
   - pip
   - pip:
     - h_transport_materials

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,5 @@ dependencies:
   - pip
   - pip:
     - h_transport_materials
-    - pybtex>=0.25
     - pyvista[all,trame]  # trame cannot be installed on conda
     - pybtex==0.25

--- a/report/_toc.yml
+++ b/report/_toc.yml
@@ -31,9 +31,9 @@ parts:
         sections:
           - file: verification/mes/tmap_1a
           - file: verification/mes/tmap_1b
-          - file: verification/mes/tmap_1c
-          - file: verification/mes/tmap_1da
-          - file: verification/mes/tmap_1db
+          # - file: verification/mes/tmap_1c
+          # - file: verification/mes/tmap_1da
+          # - file: verification/mes/tmap_1db
           - file: verification/mes/tmap_1e
   - caption: Validation
     chapters:

--- a/report/_toc.yml
+++ b/report/_toc.yml
@@ -15,7 +15,7 @@ parts:
       - file: verification/simple_cases
         sections:
           - file: verification/mms/simple.md
-          # - file: verification/mms/simple_transient
+          - file: verification/mms/simple_transient
           - file: verification/mms/simple_temperature
       - file: verification/mms/fluxes
       - file: verification/mms/heat_transfer

--- a/report/_toc.yml
+++ b/report/_toc.yml
@@ -31,9 +31,9 @@ parts:
         sections:
           - file: verification/mes/tmap_1a
           - file: verification/mes/tmap_1b
-          # - file: verification/mes/tmap_1c
-          # - file: verification/mes/tmap_1da
-          # - file: verification/mes/tmap_1db
+          - file: verification/mes/tmap_1c
+          - file: verification/mes/tmap_1da
+          - file: verification/mes/tmap_1db
           - file: verification/mes/tmap_1e
   - caption: Validation
     chapters:

--- a/report/requirements.txt
+++ b/report/requirements.txt
@@ -1,3 +1,4 @@
 jupyter-book
 matplotlib
 numpy
+Xvfb

--- a/report/requirements.txt
+++ b/report/requirements.txt
@@ -1,4 +1,3 @@
 jupyter-book
 matplotlib
 numpy
-Xvfb

--- a/report/verification/mes/radioactive_decay.md
+++ b/report/verification/mes/radioactive_decay.md
@@ -5,9 +5,9 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.7
+    jupytext_version: 1.18.1
 kernelspec:
-  display_name: vv-festim-report-env-festim-2
+  display_name: vv-festim-report-env
   language: python
   name: python3
 ---
@@ -45,7 +45,6 @@ We can then run a FESTIM model with these conditions and compare the numerical s
 ## FESTIM Code
 
 ```{code-cell} ipython3
-
 import festim as F
 import numpy as np
 import matplotlib.pyplot as plt
@@ -80,7 +79,7 @@ def run_model(half_life):
 
     my_model.exports = [average_volume]
 
-    my_model.initial_conditions = [F.InitialCondition(value=initial_concentration, species=H)]
+    my_model.initial_conditions = [F.InitialConcentration(value=initial_concentration, species=H, volume=volume)]
 
     my_model.settings = F.Settings(
         atol=1e-10, rtol=1e-10, final_time=5 * half_life, transient=True
@@ -111,6 +110,7 @@ The evolution of the hydrogen concentration is computed with FESTIM and compared
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+
 from matplotlib import cm
 from matplotlib.colors import LogNorm
 

--- a/report/verification/mes/tmap_1c.md
+++ b/report/verification/mes/tmap_1c.md
@@ -139,6 +139,12 @@ $$
 
 where $h$ is the thickness of the pre-loaded region.
 
++++
+
+```{warning}
+There is an existing bug with `ProfileExport1D` class. See (this associated issue for more details)[https://github.com/festim-dev/FESTIM/issues/1046].
+```
+
 ```{code-cell} ipython3
 :tags: [hide-input]
 

--- a/report/verification/mes/tmap_1c.md
+++ b/report/verification/mes/tmap_1c.md
@@ -5,9 +5,9 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.7
+    jupytext_version: 1.18.1
 kernelspec:
-  display_name: vv-festim-report-env-festim-2
+  display_name: vv-festim-report-env
   language: python
   name: python3
 ---
@@ -46,15 +46,18 @@ class PointValue(F.VolumeQuantity):
         self.value = self.field.solution.eval(self.x0, first_cell)
         self.data.append(self.value)
 
+class Profile(F.Profile1DExport):
+    def __init__(self, field, volume, times=None):
+        super().__init__(field=field, subdomain=volume, times=times)
+        self.data = []   
+        self.t = []      
+        self.x = None    
 
-class Profile(F.VolumeQuantity):
-    def __init__(self, field, volume, times=None, filename=None):
-        super().__init__(field, volume, filename)
-        self.times = times or []
+    def compute(self, *args, **kwargs):
+        super().compute(*args, **kwargs)
 
-    def compute(self):
-        self.value = self.field.solution.x.array[:].copy()
-        self.data.append(self.value)
+        last_profile = self.data[-1].copy()
+        self.data[-1] = last_profile     
 ```
 
 ```{code-cell} ipython3
@@ -96,7 +99,7 @@ model.boundary_conditions = [
 ]
 
 initial_concentration = lambda x: ufl.conditional(x[0] <= preloaded_length, C_0, 0)
-model.initial_conditions = [F.InitialCondition(value=initial_concentration, species=H)]
+model.initial_conditions = [F.InitialConcentration(value=initial_concentration, species=H, volume=volume)]
 
 
 model.temperature = 500  # ignored in this problem
@@ -104,21 +107,28 @@ model.temperature = 500  # ignored in this problem
 
 test_points = [0.5, preloaded_length, 12]  # m
 profile_times = [0.1] + np.linspace(0, 100, num=10).tolist()[1:]
+
+
+profile_export = F.Profile1DExport(field=H, times=profile_times)
+
 model.exports = [
     PointValue(field=H, volume=volume, x0=np.array([v, 0, 0])) for v in test_points
-] + [Profile(field=H, volume=volume)]
+] + [profile_export
+] 
+
 
 model.settings = F.Settings(atol=1e-10, rtol=1e-10, final_time=100)
 model.settings.stepsize = F.Stepsize(
     initial_value=0.01,
     growth_factor=1.1,
     cutback_factor=0.9,
-    target_nb_iterations=4,
+    target_nb_iterations=10,
     milestones=profile_times,
 )
 
 model.initialise()
 model.run()
+
 ```
 
 ## Comparison with exact solution
@@ -164,24 +174,32 @@ def exact_solution(x, t):
     )
 
 
-norm = Normalize(vmin=0, vmax=max(profile_times))
-cmap = cm.viridis
+profile_export = model.exports[-1]
+times = np.array(profile_export.t)
 
+profiles_1d = [np.ravel(p) for p in profile_export.data]
+data = np.stack(profiles_1d, axis=0)
+
+x = profile_export.x
+order = np.argsort(x)
+x = x[order]
+data = data[:, order]
+
+norm = Normalize(vmin=times.min(), vmax=times.max())
+cmap = cm.viridis
 
 plt.figure()
 
-profile_export = model.exports[-1]
-data = profile_export.data
+
 for i, t in enumerate(profile_times):
     label = "exact" if i == 0 else ""
-    x = model.mesh.mesh.geometry.x[:, 0]
     y_name = f"t{t:.2e}s".replace("+", "").replace("-", "").replace(".", "")
 
-    indices = np.where(np.isclose(profile_export.t, t))[0][0]
-    y = data[indices]
-    x, y = zip(*sorted(zip(x, y)))
+    idx = np.argmin(np.abs(times - t))
+    t = times[idx]
+    y = data[idx, :]
 
-    exact_y = exact_solution(np.array(x), t)
+    exact_y = exact_solution(x, t)
 
     plt.plot(x, exact_y, linestyle="dashed", color="tab:grey", linewidth=3, label=label)
     plt.plot(x, y, color=cmap(norm(t)))

--- a/report/verification/mes/tmap_1c.md
+++ b/report/verification/mes/tmap_1c.md
@@ -10,6 +10,8 @@ kernelspec:
   display_name: vv-festim-report-env-festim-2
   language: python
   name: python3
+mystnb:
+  execution_mode: "off"
 ---
 
 # Pre-loaded semi-infinite slab

--- a/report/verification/mes/tmap_1c.md
+++ b/report/verification/mes/tmap_1c.md
@@ -10,8 +10,6 @@ kernelspec:
   display_name: vv-festim-report-env-festim-2
   language: python
   name: python3
-mystnb:
-  execution_mode: "off"
 ---
 
 # Pre-loaded semi-infinite slab

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -55,9 +55,8 @@ For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13} \ \mathrm{s}
 ```{code-cell} ipython3
 import festim as F
 import numpy as np
-from dolfinx import log
 
-log.set_level(log.LogLevel.INFO)
+
 
 # Define input parameters
 n = 3.162e22
@@ -111,7 +110,7 @@ my_model.boundary_conditions = [
     F.DirichletBC(subdomain=right_boundary, value=0, species=mobile_H),
 ]
 
-my_model.settings = F.Settings(atol=2e15, rtol=5e-8, max_iterations=30, final_time=10)
+my_model.settings = F.Settings(atol=1e10, rtol=1e-10, final_time=10)
 my_model.settings.stepsize = F.Stepsize(0.05)
 
 # my_model.settings.stepsize = F.Stepsize(
@@ -124,7 +123,43 @@ my_model.settings.stepsize = F.Stepsize(0.05)
 right_flux = F.SurfaceFlux(field=mobile_H, surface=right_boundary)
 
 my_model.exports = [right_flux]
+print(F.__version__)
 
+```
+
+```{code-cell} ipython3
+from petsc4py import PETSc
+import dolfinx
+
+# taken from https://github.com/FEniCS/dolfinx/blob/5fcb988c5b0f46b8f9183bc844d8f533a2130d6a/python/demo/demo_cahn-hilliard.py#L279C1-L286C28
+use_superlu = (
+    PETSc.IntType == np.int64
+)  # or PETSc.ScalarType == np.complex64
+sys = PETSc.Sys()  # type: ignore
+if sys.hasExternalPackage("mumps") and not use_superlu:
+    linear_solver = "mumps"
+elif sys.hasExternalPackage("superlu_dist"):
+    linear_solver = "superlu_dist"
+else:
+    linear_solver = "petsc"
+
+petsc_options = {
+    "snes_type": "newtonls",
+    "snes_linesearch_type": "none",
+    "snes_stol": np.sqrt(np.finfo(dolfinx.default_real_type).eps)
+    * 1e-2,
+    "snes_atol": my_model.settings.atol,
+    "snes_rtol": my_model.settings.rtol,
+    "snes_divergence_tolerance": "PETSC_UNLIMITED",
+    "snes_max_it": my_model.settings.max_iterations,
+    "ksp_type": "preonly",
+    "pc_type": "lu",
+    "pc_factor_mat_solver_type": linear_solver,
+}
+my_model.petsc_options = petsc_options
+```
+
+```{code-cell} ipython3
 my_model.initialise()
 my_model.run()
 ```

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -107,7 +107,7 @@ my_model.boundary_conditions = [
     F.DirichletBC(subdomain=right_boundary, value=0, species=mobile_H),
 ]
 
-my_model.settings = F.Settings(atol=1e10, rtol=1e-10, final_time=10)
+my_model.settings = F.Settings(atol=2e15, rtol=5e-8, final_time=10)
 my_model.settings.stepsize = F.Stepsize(0.05)
 
 right_flux = F.SurfaceFlux(field=mobile_H, surface=right_boundary)

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -110,13 +110,6 @@ my_model.boundary_conditions = [
 my_model.settings = F.Settings(atol=1e10, rtol=1e-10, final_time=10)
 my_model.settings.stepsize = F.Stepsize(0.05)
 
-# my_model.settings.stepsize = F.Stepsize(
-#     initial_value=1e-7,
-#     growth_factor=1.1,
-#     cutback_factor=0.9,
-#     target_nb_iterations=10,
-# )
-
 right_flux = F.SurfaceFlux(field=mobile_H, surface=right_boundary)
 
 my_model.exports = [right_flux]

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -10,6 +10,8 @@ kernelspec:
   display_name: vv-festim-report-env
   language: python
   name: python3
+mystnb:
+  execution_mode: "off"
 ---
 
 # Effective diffusivity regime

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -65,9 +65,6 @@ D_0 = 1
 E_D = 0.0
 k_0 = 1e15 / n
 p_0 = 1e13
-# k_0 = 1e12 / n
-
-
 E_p = 100 * F.k_B
 T = 1000
 sample_depth = 1

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -113,7 +113,6 @@ my_model.settings.stepsize = F.Stepsize(0.05)
 right_flux = F.SurfaceFlux(field=mobile_H, surface=right_boundary)
 
 my_model.exports = [right_flux]
-print(F.__version__)
 
 ```
 

--- a/report/verification/mes/tmap_1da.md
+++ b/report/verification/mes/tmap_1da.md
@@ -5,13 +5,11 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.7
+    jupytext_version: 1.18.1
 kernelspec:
   display_name: vv-festim-report-env
   language: python
   name: python3
-mystnb:
-  execution_mode: "off"
 ---
 
 # Effective diffusivity regime
@@ -54,9 +52,12 @@ For this case, $\lambda=\sqrt{10^{-15}} \ \mathrm{m}$, $\nu=10^{13} \ \mathrm{s}
 
 ## FESTIM Code
 
-```{code-cell}
+```{code-cell} ipython3
 import festim as F
 import numpy as np
+from dolfinx import log
+
+log.set_level(log.LogLevel.INFO)
 
 # Define input parameters
 n = 3.162e22
@@ -65,6 +66,9 @@ D_0 = 1
 E_D = 0.0
 k_0 = 1e15 / n
 p_0 = 1e13
+# k_0 = 1e12 / n
+
+
 E_p = 100 * F.k_B
 T = 1000
 sample_depth = 1
@@ -108,8 +112,14 @@ my_model.boundary_conditions = [
 ]
 
 my_model.settings = F.Settings(atol=2e15, rtol=5e-8, max_iterations=30, final_time=10)
-
 my_model.settings.stepsize = F.Stepsize(0.05)
+
+# my_model.settings.stepsize = F.Stepsize(
+#     initial_value=1e-7,
+#     growth_factor=1.1,
+#     cutback_factor=0.9,
+#     target_nb_iterations=10,
+# )
 
 right_flux = F.SurfaceFlux(field=mobile_H, surface=right_boundary)
 
@@ -121,7 +131,7 @@ my_model.run()
 
 ## Comparison with exact solution
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 import plotly.graph_objects as go

--- a/report/verification/mes/tmap_1db.md
+++ b/report/verification/mes/tmap_1db.md
@@ -5,13 +5,11 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.7
+    jupytext_version: 1.18.1
 kernelspec:
   display_name: vv-festim-report-env
   language: python
   name: python3
-mystnb:
-  execution_mode: "off"
 ---
 
 # Strong trapping regime

--- a/report/verification/mes/tmap_1db.md
+++ b/report/verification/mes/tmap_1db.md
@@ -10,6 +10,8 @@ kernelspec:
   display_name: vv-festim-report-env
   language: python
   name: python3
+mystnb:
+  execution_mode: "off"
 ---
 
 # Strong trapping regime

--- a/report/verification/mes/tmap_1db.md
+++ b/report/verification/mes/tmap_1db.md
@@ -114,7 +114,6 @@ my_model.settings.stepsize = F.Stepsize(
 right_flux = F.SurfaceFlux(field=mobile_H, surface=right_boundary)
 
 my_model.exports = [right_flux]
-print(F.__version__)
 ```
 
 ```{code-cell} ipython3

--- a/report/verification/mes/tmap_1db.md
+++ b/report/verification/mes/tmap_1db.md
@@ -101,20 +101,56 @@ my_model.boundary_conditions = [
     F.DirichletBC(subdomain=right_boundary, value=0, species=mobile_H),
 ]
 
-my_model.settings = F.Settings(atol=2e15, rtol=5e-8, max_iterations=30, final_time=1000)
+my_model.settings = F.Settings(atol=1e10, rtol=1e-10, final_time=1000)
 
 my_model.settings.stepsize = F.Stepsize(
-    initial_value=1e-6,
+    # initial_value=1e-6,
+    initial_value=0.01,
     growth_factor=1.1,
     cutback_factor=0.9,
-    target_nb_iterations=30,
-    max_stepsize=2,
+    target_nb_iterations=4,
 )
 
 right_flux = F.SurfaceFlux(field=mobile_H, surface=right_boundary)
 
 my_model.exports = [right_flux]
 
+
+```
+
+```{code-cell} ipython3
+from petsc4py import PETSc
+import dolfinx
+
+# taken from https://github.com/FEniCS/dolfinx/blob/5fcb988c5b0f46b8f9183bc844d8f533a2130d6a/python/demo/demo_cahn-hilliard.py#L279C1-L286C28
+use_superlu = (
+    PETSc.IntType == np.int64
+)  # or PETSc.ScalarType == np.complex64
+sys = PETSc.Sys()  # type: ignore
+if sys.hasExternalPackage("mumps") and not use_superlu:
+    linear_solver = "mumps"
+elif sys.hasExternalPackage("superlu_dist"):
+    linear_solver = "superlu_dist"
+else:
+    linear_solver = "petsc"
+
+petsc_options = {
+    "snes_type": "newtonls",
+    "snes_linesearch_type": "none",
+    "snes_stol": np.sqrt(np.finfo(dolfinx.default_real_type).eps)
+    * 1e-2,
+    "snes_atol": my_model.settings.atol,
+    "snes_rtol": my_model.settings.rtol,
+    "snes_divergence_tolerance": "PETSC_UNLIMITED",
+    "snes_max_it": my_model.settings.max_iterations,
+    "ksp_type": "preonly",
+    "pc_type": "lu",
+    "pc_factor_mat_solver_type": linear_solver,
+}
+my_model.petsc_options = petsc_options
+```
+
+```{code-cell} ipython3
 my_model.initialise()
 my_model.run()
 ```

--- a/report/verification/mes/tmap_1db.md
+++ b/report/verification/mes/tmap_1db.md
@@ -101,21 +101,20 @@ my_model.boundary_conditions = [
     F.DirichletBC(subdomain=right_boundary, value=0, species=mobile_H),
 ]
 
-my_model.settings = F.Settings(atol=1e10, rtol=1e-10, final_time=1000)
+my_model.settings = F.Settings(atol=2e15, rtol=5e-8, max_iterations=30, final_time=1000)
 
 my_model.settings.stepsize = F.Stepsize(
-    # initial_value=1e-6,
-    initial_value=0.01,
+    initial_value=1e-6,
     growth_factor=1.1,
     cutback_factor=0.9,
-    target_nb_iterations=4,
+    target_nb_iterations=30,
+    max_stepsize=2,
 )
 
 right_flux = F.SurfaceFlux(field=mobile_H, surface=right_boundary)
 
 my_model.exports = [right_flux]
-
-
+print(F.__version__)
 ```
 
 ```{code-cell} ipython3
@@ -146,6 +145,7 @@ petsc_options = {
     "ksp_type": "preonly",
     "pc_type": "lu",
     "pc_factor_mat_solver_type": linear_solver,
+    # "snes_monitor": None,
 }
 my_model.petsc_options = petsc_options
 ```

--- a/report/verification/mms/simple_transient.md
+++ b/report/verification/mms/simple_transient.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.18.1
 kernelspec:
   display_name: vv-festim-report-env
   language: python
@@ -61,76 +61,58 @@ We can then run a FESTIM model with these values and compare the numerical solut
 :tags: [hide-cell]
 
 import festim as F
-import sympy as sp
-import fenics as f
-import matplotlib as mpl
-import matplotlib.pyplot as plt
+from mpi4py import MPI
+import dolfinx
 import numpy as np
 
-# Create and mark the mesh
+# --- Create and mark the mesh ---
 nx = ny = 100
-fenics_mesh = f.UnitSquareMesh(nx, ny)
+fenics_mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, nx, ny)
 
+# --- FESTIM model setup ---
+my_model = F.HydrogenTransportProblem()
+H = F.Species("H")
+my_model.species = [H]
+my_model.mesh = F.Mesh(fenics_mesh)
 
-volume_markers = f.MeshFunction("size_t", fenics_mesh, fenics_mesh.topology().dim())
-volume_markers.set_all(1)
-
-surface_markers = f.MeshFunction(
-    "size_t", fenics_mesh, fenics_mesh.topology().dim() - 1
-)
-surface_markers.set_all(0)
-
-
-class Boundary(f.SubDomain):
-    def inside(self, x, on_boundary):
-        return on_boundary
-
-
-boundary = Boundary()
-boundary.mark(surface_markers, 1)
-
-# Create the FESTIM model
-my_model = F.Simulation()
-
-my_model.mesh = F.Mesh(
-    fenics_mesh, volume_markers=volume_markers, surface_markers=surface_markers
-)
-
-# Variational formulation
-exact_solution = 1 + 2 * F.x**2 + 3 * F.t * F.y**2 + 2 * F.t  # exact solution
-
-exact_solution_copy = exact_solution.subs(F.x, F.x)
-
+# --- materials ---
 D = 2
+material = F.Material(D_0=D, E_D=0)
 
-my_model.sources = [
-    F.Source(2 + 3 * F.y**2 - (4 + 6 * F.t) * D, volume=1, field="solute"),
-]
+# --- subdomains ---
+volume = F.VolumeSubdomain(id=1, material=material)
+boundary = F.SurfaceSubdomain(id=1)
+my_model.subdomains = [volume, boundary]
 
+# --- define the exact solution ---
+exact_solution = lambda x,t:1 + 2 * x[0]**2 + 3 * t * x[1]**2 + 2 * t 
+
+# --- define the sources and boundary conditions ---
+my_model.sources = [(F.ParticleSource(value=lambda x, t: 2 + 3 * x[1]**2 - (4 + 6 * t) * D , volume = volume, species=H))]
 my_model.boundary_conditions = [
-    F.DirichletBC(surfaces=[1], value=exact_solution, field="solute"),
+    F.FixedConcentrationBC(subdomain=boundary, value=exact_solution, species=H),
 ]
 
-my_model.materials = F.Material(id=1, D_0=D, E_D=0)
+my_model.temperature = 500  # ignored in this problem
 
-my_model.T = F.Temperature(500)  # ignored in this problem
-
+# --- output control ---
 xdmf_file_name = "simple_transient_mobile.xdmf"
+vtx_file_name = "simple_transient_mobile.bp"
 my_model.exports = [
-    F.XDMFExport(field="solute", filename=xdmf_file_name, checkpoint=True)
+    F.XDMFExport(field=H, filename=xdmf_file_name),
+    F.VTXSpeciesExport(field=H, filename=vtx_file_name, checkpoint=True),
+    F.VTXSpeciesExport(field=H, filename="out.bp", checkpoint=False)
 ]
 
+
+# --- time stepping ---
 final_time = 17
-slices = 4
-slice_size = final_time / slices
-milestones = list(np.linspace(slice_size, final_time, slices))
-
-my_model.dt = F.Stepsize(initial_value=1, milestones=milestones)
-
+dt = F.Stepsize(initial_value=1)
 my_model.settings = F.Settings(
-    absolute_tolerance=1e-10,
-    relative_tolerance=1e-10,
+    atol=1e-10,
+    rtol=1e-10,
     final_time=final_time,
+    stepsize=dt,
 )
 
 my_model.initialise()
@@ -142,153 +124,81 @@ my_model.run()
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-from fenics import XDMFFile, FunctionSpace, Function, plot
+import pyvista
+from dolfinx.plot import vtk_mesh
+import adios4dolfinx
+from mpi4py import MPI
+
+"""
+Post-process FESTIM v2/VTX (.bp) output in Python with PyVista.
+
+- Reads selected timesteps from a VTX/ADIOS2 file using adios4dolfinx
+- For each timestep, computes the corresponding analytic "exact" field
+- Plots a grid of comparisons between simulation and exact solutions:
+  1 row per time instant
+  2 columns: left = simulation, right = exact
+"""
 
 
-def load_xdmf(mesh, filename, field, element="CG", counter=-1):
-    """Loads a XDMF file and store its content to a fenics.Function
+pyvista.start_xvfb()
+pyvista.set_jupyter_backend("html")
 
-    Args:
-        mesh (fenics.mesh): the mesh of the function
-        filename (str): the XDMF filename
-        field (str): the name of the field in the XDMF file
-        element (str, optional): Finite element of the function.
-            Defaults to "CG".
-        counter (int, optional): timestep in the file, -1 is the
-            last timestep. Defaults to -1.
-
-    Returns:
-        fenics.Function: the content of the XDMF file as a Function
-    """
-
-    V = FunctionSpace(mesh, element, 1)
-    u = Function(V)
-
-    XDMFFile(filename).read_checkpoint(u, field, counter)
-    return u
+def read_computed_solution(time: float):
+    """Load FEM function at a given time from a VTX/ADIOS2 file."""
+    mesh = adios4dolfinx.read_mesh(vtx_file_name, comm=MPI.COMM_WORLD)
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
+    u_in = dolfinx.fem.Function(V)
+    adios4dolfinx.read_function(vtx_file_name, u_in, time=time, name=H.name)
+    return u_in
 
 
-fig, axs = plt.subplots(
-    slices, 3, figsize=(slices * 2.3, slices * 2.5 + 1)
-)  # tweak figsize if needed
-fig.tight_layout()
+def get_u_grid(u: dolfinx.fem.Function, label: str):
+    """Convert a FEM function to a PyVista UnstructuredGrid and attach nodal data."""
+    u_topology, u_cell_types, u_geometry = vtk_mesh(u.function_space)
+    u_grid = pyvista.UnstructuredGrid(u_topology, u_cell_types, u_geometry)
+    u_grid.point_data[label] = u.x.array.real
+    u_grid.set_active_scalars(label)
+    return u_grid
 
+timestamps = adios4dolfinx.read_timestamps(vtx_file_name, MPI.COMM_WORLD, function_name=H.name)
 
-def compute_arc_length(xs, ys):
-    """Computes the arc length of x,y points based
-    on x and y arrays
-    """
-    points = np.vstack((xs, ys)).T
-    distance = np.linalg.norm(points[1:] - points[:-1], axis=1)
-    arc_length = np.insert(np.cumsum(distance), 0, [0.0])
-    return arc_length
+for t_val in timestamps[::6]:
+    t_val = float(t_val)
 
+    computed_solution = read_computed_solution(t_val)
+    u_grid_mobile = get_u_grid(computed_solution, "c_simulation")
 
-def exists_close(x, list):
-    return any(np.isclose(x, t) for t in list)
-
-
-xdmf_times = F.extract_xdmf_times(xdmf_file_name)
-counters = [i for (i, time) in enumerate(xdmf_times) if exists_close(time, milestones)]
-
-for i, counter in enumerate(counters):
-    time = xdmf_times[counter]
-
-    c_exact = f.Expression(
-        sp.printing.ccode(exact_solution_copy.subs(F.t, time)), degree=4
+    exact_solution_function = dolfinx.fem.Function(computed_solution.function_space)
+    exact_solution_function.interpolate(
+        lambda X: 1 + 2 * X[0] ** 2 + 3 * t_val * X[1] ** 2 + 2 * t_val
     )
-    c_exact = f.project(c_exact, f.FunctionSpace(my_model.mesh.mesh, "CG", 1))
+    u_grid_mobile_exact = get_u_grid(exact_solution_function, "c_exact")
 
-    computed_solution = load_xdmf(
-        fenics_mesh, xdmf_file_name, "mobile_concentration", "CG", counter
-    )
-    E = f.errornorm(computed_solution, c_exact, "L2")
+    print(f"t={float(t_val):g}s, Simulation result (left) vs. Exact result (right)")
+    u_plotter = pyvista.Plotter(shape=(1, 2))
+    
+    u_plotter.subplot(0, 0)
+    u_plotter.add_title("simulation",font_size = 20, color = "black")
+    u_plotter.set_background("white")
+    u_plotter.add_mesh(u_grid_mobile)
+    contours_sim = u_grid_mobile.contour(9)
+    u_plotter.add_mesh(contours_sim, color="white")
+    u_plotter.add_text("Simulation", font_size=18,color="black", position="upper_edge")
+    u_plotter.view_xy()
 
-    # plot exact solution and computed solution
-    plt.sca(axs[i, 0])
-    if i == 0:
-        plt.title(f"Exact")
-    plt.annotate(
-        f"t={time}s",
-        xy=(0.5, 1),
-        xytext=(-axs[i, 0].yaxis.labelpad - 3, 0),
-        xycoords=axs[i, 0].yaxis.label,
-        textcoords="offset points",
-        size="large",
-        ha="right",
-        va="center",
-    )
-    CS1 = f.plot(c_exact, cmap="inferno")
-    plt.sca(axs[i, 1])
-    if i == 0:
-        plt.title(f"Computed")
-    CS2 = f.plot(computed_solution, cmap="inferno")
+    u_plotter.subplot(0, 1)
+    u_plotter.set_background("white")
+    u_plotter.add_mesh(u_grid_mobile_exact)
+    contours_ex = u_grid_mobile_exact.contour(9)
+    u_plotter.add_mesh(contours_ex, color="white")
+    u_plotter.view_xy()
+    u_plotter.add_text("Exact", font_size=18,color="black", position="upper_edge")
+    
 
-    plt.colorbar(CS1, ax=[axs[i, 0]], shrink=0.8)
-    plt.colorbar(CS2, ax=[axs[i, 1]], shrink=0.8)
-
-    axs[i, 0].sharey(axs[i, 1])
-    plt.setp(axs[i, 1].get_yticklabels(), visible=False)
-
-    for CS in [CS1, CS2]:
-        CS.set_edgecolor("face")
-
-    # define the profiles
-    profiles = [
-        {"start": (0.0, 0.0), "end": (1.0, 1.0)},
-        {"start": (0.2, 0.8), "end": (0.7, 0.2)},
-        {"start": (0.2, 0.6), "end": (0.8, 0.8)},
-    ]
-
-    # plot the profiles on the right subplot
-    for profile in profiles:
-        start_x, start_y = profile["start"]
-        end_x, end_y = profile["end"]
-        plt.sca(axs[i, 1])
-        (l,) = plt.plot([start_x, end_x], [start_y, end_y])
-
-        plt.sca(axs[i, 2])
-
-        points_x_exact = np.linspace(start_x, end_x, num=30)
-        points_y_exact = np.linspace(start_y, end_y, num=30)
-        arc_length_exact = compute_arc_length(points_x_exact, points_y_exact)
-        u_values = [c_exact(x, y) for x, y in zip(points_x_exact, points_y_exact)]
-
-        points_x = np.linspace(start_x, end_x, num=100)
-        points_y = np.linspace(start_y, end_y, num=100)
-        arc_lengths = sorted(compute_arc_length(points_x, points_y))
-        computed_values = [computed_solution(x, y) for x, y in zip(points_x, points_y)]
-
-        (exact_line,) = plt.plot(
-            arc_length_exact,
-            u_values,
-            color=l.get_color(),
-            marker="o",
-            linestyle="None",
-            alpha=0.3,
-        )
-        (computed_line,) = plt.plot(arc_lengths, computed_values, color=l.get_color())
-
-    plt.sca(axs[i, 2])
-    plt.xlabel("Arc length")
-    if i == 0:
-        legend_marker = mpl.lines.Line2D(
-            [],
-            [],
-            color="black",
-            marker=exact_line.get_marker(),
-            linestyle="None",
-            label="Exact",
-        )
-        legend_line = mpl.lines.Line2D([], [], color="black", label="Computed")
-        plt.legend(
-            [legend_marker, legend_line],
-            [legend_marker.get_label(), legend_line.get_label()],
-        )
-    plt.grid(alpha=0.3)
-    plt.gca().spines[["right", "top"]].set_visible(False)
-
-plt.show()
+    if not pyvista.OFF_SCREEN:
+        u_plotter.show()
+    else:
+        figure = u_plotter.screenshot("comparison.png")
 ```
 
 ## Compute convergence rates
@@ -300,53 +210,70 @@ This is expected for this particular problem as first order finite elements are 
 ```{code-cell} ipython3
 :tags: [hide-cell]
 
-def make_unit_square_mesh(n):
-    """
-    Makes a festim Mesh with sides n x n for a total of n^2 cells.
-    Sets surface markers on the boundary to 1, otherwise 0.
-    """
+import matplotlib.pyplot as plt
+import ufl
+import dolfinx
 
-    fenics_mesh = f.UnitSquareMesh(n, n)
 
-    volume_markers = f.MeshFunction("size_t", fenics_mesh, fenics_mesh.topology().dim())
-    volume_markers.set_all(1)
+def error_L2(u_computed, u_exact, degree_raise=3):
+    # Create higher order function space
+    degree = u_computed.function_space.ufl_element().degree
+    family = u_computed.function_space.ufl_element().family_name
+    mesh = u_computed.function_space.mesh
+    W = dolfinx.fem.functionspace(mesh, (family, degree + degree_raise))
 
-    surface_markers = f.MeshFunction(
-        "size_t", fenics_mesh, fenics_mesh.topology().dim() - 1
+    # Interpolate exact solution, special handling if exact solution
+    # is a ufl expression or a python lambda function
+    u_ex_W = dolfinx.fem.Function(W)
+    if isinstance(u_exact, ufl.core.expr.Expr):
+        u_expr = dolfinx.fem.Expression(u_exact, W.element.interpolation_points)
+        u_ex_W.interpolate(u_expr)
+    else:
+        u_ex_W.interpolate(u_exact)
+
+    # Integrate the error
+    error = dolfinx.fem.form(
+        ufl.inner(u_computed - u_ex_W, u_computed - u_ex_W) * ufl.dx
     )
-    surface_markers.set_all(0)
-
-    class Boundary(f.SubDomain):
-        def inside(self, x, on_boundary):
-            return on_boundary
-
-    boundary = Boundary()
-    boundary.mark(surface_markers, 1)
-
-    return F.Mesh(fenics_mesh, volume_markers, surface_markers)
+    error_local = dolfinx.fem.assemble_scalar(error)
+    error_global = mesh.comm.allreduce(error_local, op=MPI.SUM)
+    return np.sqrt(error_global)
 
 
 errors = []
 ns = [5, 10, 20, 30, 50, 100, 150]
 
 for n in ns:
-    my_model.mesh = make_unit_square_mesh(n)
+    nx = ny = n
+    fenics_mesh = fenics_mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, nx, ny)
 
-    my_model.initialise()
-    my_model.run()
+    new_model = F.HydrogenTransportProblem()
+    new_model.mesh = F.Mesh(fenics_mesh)
 
-    computed_solution = my_model.h_transport_problem.mobile.post_processing_solution
-    errors.append(f.errornorm(computed_solution, c_exact, "L2"))
-```
+    new_model.species = my_model.species
+    new_model.subdomains = my_model.subdomains
+    new_model.sources = my_model.sources
+    new_model.boundary_conditions = my_model.boundary_conditions
+    new_model.temperature = my_model.temperature
+    new_model.settings = my_model.settings
 
-```{code-cell} ipython3
-:tags: [hide-input]
+    new_model.initialise()
+    new_model.run()
+    
+    # by default, get the last time step solution
+    computed_solution = H.solution
+    exact_solution_function = dolfinx.fem.Function(computed_solution.function_space)
+    exact_solution_function.interpolate(
+        lambda X: 1 + 2 * X[0] ** 2 + 3 * final_time * X[1] ** 2 + 2 * final_time
+    )
+    errors.append(error_L2(computed_solution, exact_solution_function))
 
 h = 1 / np.array(ns)
 
 plt.loglog(h, errors, marker="o")
 plt.xlabel("Element size")
 plt.ylabel("L2 error")
+plt.title("Mesh convergence study for transient diffusion problem at t=17s")
 
 plt.loglog(h, 2 * h**2, linestyle="--", color="black")
 plt.annotate(

--- a/report/verification/mms/simple_transient.md
+++ b/report/verification/mms/simple_transient.md
@@ -1,0 +1,358 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.2
+kernelspec:
+  display_name: vv-festim-report-env
+  language: python
+  name: python3
+---
+
+# Simple transient diffusion case
+
+```{tags} 2D, MMS, transient
+```
+
+This is a simple transient MMS example.
+We will only consider diffusion of hydrogen in a unit square domain $\Omega$ at steady state with an homogeneous diffusion coefficient $D$.
+Moreover, a Dirichlet boundary condition will be assumed on the boundaries $\partial \Omega $.
+
+The problem is therefore:
+
+$$
+\begin{align}
+    &\nabla \cdot (D \ \nabla{c}) - \frac{\partial c}{\partial t} = -S  \quad \text{on }  \Omega  ; \ t\geq 0 \\
+    & c = c_0 \quad \text{on }  \partial \Omega ; \ t\geq 0 \\
+    & c = c_\mathrm{initial} \quad \text{on } \partial \Omega ; \ \text{at } t=0
+\end{align}
+$$(problem_simple_transient)
+
+The exact solution for mobile concentration is:
+
+$$
+\begin{equation}
+    c_\mathrm{exact} = 1 + 2 x^2 + 3 y^2 t + 2t
+\end{equation}
+$$(c_exact_simple_transient)
+
+```{note}
+We use a manufactured solution that varies linearly with time ($t^1$), as the backward Euler scheme provides an exact solution in this case.
+```
+
+Injecting {eq}`c_exact_simple_transient` in {eq}`problem_simple_transient`, we obtain the expressions of $S$, $c_0$, and $c_\mathrm{initial}$:
+
+\begin{align}
+    & S = 2 + 3 y^2 - (4 + 6t) D \\
+    & c_0 = c_\mathrm{exact} \\
+    & c_\mathrm{initial} = c_\mathrm{exact}(t=0)
+\end{align}
+
+We can then run a FESTIM model with these values and compare the numerical solution with $c_\mathrm{exact}$.
+
++++
+
+## FESTIM code
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+import festim as F
+import sympy as sp
+import fenics as f
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Create and mark the mesh
+nx = ny = 100
+fenics_mesh = f.UnitSquareMesh(nx, ny)
+
+
+volume_markers = f.MeshFunction("size_t", fenics_mesh, fenics_mesh.topology().dim())
+volume_markers.set_all(1)
+
+surface_markers = f.MeshFunction(
+    "size_t", fenics_mesh, fenics_mesh.topology().dim() - 1
+)
+surface_markers.set_all(0)
+
+
+class Boundary(f.SubDomain):
+    def inside(self, x, on_boundary):
+        return on_boundary
+
+
+boundary = Boundary()
+boundary.mark(surface_markers, 1)
+
+# Create the FESTIM model
+my_model = F.Simulation()
+
+my_model.mesh = F.Mesh(
+    fenics_mesh, volume_markers=volume_markers, surface_markers=surface_markers
+)
+
+# Variational formulation
+exact_solution = 1 + 2 * F.x**2 + 3 * F.t * F.y**2 + 2 * F.t  # exact solution
+
+exact_solution_copy = exact_solution.subs(F.x, F.x)
+
+D = 2
+
+my_model.sources = [
+    F.Source(2 + 3 * F.y**2 - (4 + 6 * F.t) * D, volume=1, field="solute"),
+]
+
+my_model.boundary_conditions = [
+    F.DirichletBC(surfaces=[1], value=exact_solution, field="solute"),
+]
+
+my_model.materials = F.Material(id=1, D_0=D, E_D=0)
+
+my_model.T = F.Temperature(500)  # ignored in this problem
+
+xdmf_file_name = "simple_transient_mobile.xdmf"
+my_model.exports = [
+    F.XDMFExport(field="solute", filename=xdmf_file_name, checkpoint=True)
+]
+
+final_time = 17
+slices = 4
+slice_size = final_time / slices
+milestones = list(np.linspace(slice_size, final_time, slices))
+
+my_model.dt = F.Stepsize(initial_value=1, milestones=milestones)
+
+my_model.settings = F.Settings(
+    absolute_tolerance=1e-10,
+    relative_tolerance=1e-10,
+    final_time=final_time,
+)
+
+my_model.initialise()
+my_model.run()
+```
+
+## Comparison with exact solution
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+from fenics import XDMFFile, FunctionSpace, Function, plot
+
+
+def load_xdmf(mesh, filename, field, element="CG", counter=-1):
+    """Loads a XDMF file and store its content to a fenics.Function
+
+    Args:
+        mesh (fenics.mesh): the mesh of the function
+        filename (str): the XDMF filename
+        field (str): the name of the field in the XDMF file
+        element (str, optional): Finite element of the function.
+            Defaults to "CG".
+        counter (int, optional): timestep in the file, -1 is the
+            last timestep. Defaults to -1.
+
+    Returns:
+        fenics.Function: the content of the XDMF file as a Function
+    """
+
+    V = FunctionSpace(mesh, element, 1)
+    u = Function(V)
+
+    XDMFFile(filename).read_checkpoint(u, field, counter)
+    return u
+
+
+fig, axs = plt.subplots(
+    slices, 3, figsize=(slices * 2.3, slices * 2.5 + 1)
+)  # tweak figsize if needed
+fig.tight_layout()
+
+
+def compute_arc_length(xs, ys):
+    """Computes the arc length of x,y points based
+    on x and y arrays
+    """
+    points = np.vstack((xs, ys)).T
+    distance = np.linalg.norm(points[1:] - points[:-1], axis=1)
+    arc_length = np.insert(np.cumsum(distance), 0, [0.0])
+    return arc_length
+
+
+def exists_close(x, list):
+    return any(np.isclose(x, t) for t in list)
+
+
+xdmf_times = F.extract_xdmf_times(xdmf_file_name)
+counters = [i for (i, time) in enumerate(xdmf_times) if exists_close(time, milestones)]
+
+for i, counter in enumerate(counters):
+    time = xdmf_times[counter]
+
+    c_exact = f.Expression(
+        sp.printing.ccode(exact_solution_copy.subs(F.t, time)), degree=4
+    )
+    c_exact = f.project(c_exact, f.FunctionSpace(my_model.mesh.mesh, "CG", 1))
+
+    computed_solution = load_xdmf(
+        fenics_mesh, xdmf_file_name, "mobile_concentration", "CG", counter
+    )
+    E = f.errornorm(computed_solution, c_exact, "L2")
+
+    # plot exact solution and computed solution
+    plt.sca(axs[i, 0])
+    if i == 0:
+        plt.title(f"Exact")
+    plt.annotate(
+        f"t={time}s",
+        xy=(0.5, 1),
+        xytext=(-axs[i, 0].yaxis.labelpad - 3, 0),
+        xycoords=axs[i, 0].yaxis.label,
+        textcoords="offset points",
+        size="large",
+        ha="right",
+        va="center",
+    )
+    CS1 = f.plot(c_exact, cmap="inferno")
+    plt.sca(axs[i, 1])
+    if i == 0:
+        plt.title(f"Computed")
+    CS2 = f.plot(computed_solution, cmap="inferno")
+
+    plt.colorbar(CS1, ax=[axs[i, 0]], shrink=0.8)
+    plt.colorbar(CS2, ax=[axs[i, 1]], shrink=0.8)
+
+    axs[i, 0].sharey(axs[i, 1])
+    plt.setp(axs[i, 1].get_yticklabels(), visible=False)
+
+    for CS in [CS1, CS2]:
+        CS.set_edgecolor("face")
+
+    # define the profiles
+    profiles = [
+        {"start": (0.0, 0.0), "end": (1.0, 1.0)},
+        {"start": (0.2, 0.8), "end": (0.7, 0.2)},
+        {"start": (0.2, 0.6), "end": (0.8, 0.8)},
+    ]
+
+    # plot the profiles on the right subplot
+    for profile in profiles:
+        start_x, start_y = profile["start"]
+        end_x, end_y = profile["end"]
+        plt.sca(axs[i, 1])
+        (l,) = plt.plot([start_x, end_x], [start_y, end_y])
+
+        plt.sca(axs[i, 2])
+
+        points_x_exact = np.linspace(start_x, end_x, num=30)
+        points_y_exact = np.linspace(start_y, end_y, num=30)
+        arc_length_exact = compute_arc_length(points_x_exact, points_y_exact)
+        u_values = [c_exact(x, y) for x, y in zip(points_x_exact, points_y_exact)]
+
+        points_x = np.linspace(start_x, end_x, num=100)
+        points_y = np.linspace(start_y, end_y, num=100)
+        arc_lengths = sorted(compute_arc_length(points_x, points_y))
+        computed_values = [computed_solution(x, y) for x, y in zip(points_x, points_y)]
+
+        (exact_line,) = plt.plot(
+            arc_length_exact,
+            u_values,
+            color=l.get_color(),
+            marker="o",
+            linestyle="None",
+            alpha=0.3,
+        )
+        (computed_line,) = plt.plot(arc_lengths, computed_values, color=l.get_color())
+
+    plt.sca(axs[i, 2])
+    plt.xlabel("Arc length")
+    if i == 0:
+        legend_marker = mpl.lines.Line2D(
+            [],
+            [],
+            color="black",
+            marker=exact_line.get_marker(),
+            linestyle="None",
+            label="Exact",
+        )
+        legend_line = mpl.lines.Line2D([], [], color="black", label="Computed")
+        plt.legend(
+            [legend_marker, legend_line],
+            [legend_marker.get_label(), legend_line.get_label()],
+        )
+    plt.grid(alpha=0.3)
+    plt.gca().spines[["right", "top"]].set_visible(False)
+
+plt.show()
+```
+
+## Compute convergence rates
+
+It is also possible to compute how the numerical error decreases as we increase the number of cells.
+By iteratively refining the mesh, we find that the error exhibits a second order convergence rate.
+This is expected for this particular problem as first order finite elements are used.
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+def make_unit_square_mesh(n):
+    """
+    Makes a festim Mesh with sides n x n for a total of n^2 cells.
+    Sets surface markers on the boundary to 1, otherwise 0.
+    """
+
+    fenics_mesh = f.UnitSquareMesh(n, n)
+
+    volume_markers = f.MeshFunction("size_t", fenics_mesh, fenics_mesh.topology().dim())
+    volume_markers.set_all(1)
+
+    surface_markers = f.MeshFunction(
+        "size_t", fenics_mesh, fenics_mesh.topology().dim() - 1
+    )
+    surface_markers.set_all(0)
+
+    class Boundary(f.SubDomain):
+        def inside(self, x, on_boundary):
+            return on_boundary
+
+    boundary = Boundary()
+    boundary.mark(surface_markers, 1)
+
+    return F.Mesh(fenics_mesh, volume_markers, surface_markers)
+
+
+errors = []
+ns = [5, 10, 20, 30, 50, 100, 150]
+
+for n in ns:
+    my_model.mesh = make_unit_square_mesh(n)
+
+    my_model.initialise()
+    my_model.run()
+
+    computed_solution = my_model.h_transport_problem.mobile.post_processing_solution
+    errors.append(f.errornorm(computed_solution, c_exact, "L2"))
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+h = 1 / np.array(ns)
+
+plt.loglog(h, errors, marker="o")
+plt.xlabel("Element size")
+plt.ylabel("L2 error")
+
+plt.loglog(h, 2 * h**2, linestyle="--", color="black")
+plt.annotate(
+    "2nd order", (h[0], 2 * h[0] ** 2), textcoords="offset points", xytext=(10, 0)
+)
+
+plt.grid(alpha=0.3)
+plt.gca().spines[["right", "top"]].set_visible(False)
+```


### PR DESCRIPTION
Summary of updates to the V-V book:

1. Updated ```environment.yml``` and ```requirement.txt```
- Reflect the upgrade from FESTIM v2.0a3 to the FESTIM v2.0b release.
- Synced dependencies to ensure consistent, reproducible environments.

2. Added a simple transient case
- Included a minimal working transient example in the documentation.
- Updated the table of contents to integrate this new case.

3. Fixed the radioactive decay example

- Corrected the typo in the input parameter name: ```intialcondition``` → ```initialconcentration```.

4. Fixed the broken tmap cases.

- tmap_1c
- tmap_1da
- tmap_1db